### PR TITLE
Message subclassing

### DIFF
--- a/example/subclass.rb
+++ b/example/subclass.rb
@@ -8,10 +8,17 @@ Thread.abort_on_exception = true
 #First our subclass
 
 class TimestampedMessage < DripDrop::Message
-  def initialize(*args)
-    super
-    @head[:timestamps] ||= []
-    @head[:timestamps] << Time.now
+  def self.create_message(*args)
+    obj = super
+    obj.head[:timestamps] = []
+    obj.head[:timestamps] << Time.now
+    obj
+  end
+
+  def self.recreate_message(*args)
+    obj = super
+    obj.head[:timestamps] << Time.now.to_s
+    obj
   end
 end
 
@@ -22,21 +29,12 @@ end
 
 DripDrop.default_message_class = TimestampedMessage
 
-DripDrop::Node.new do
+node = DripDrop::Node.new do
   push1 = zmq_push("tcp://127.0.0.1:2201", :bind)
   push2 = zmq_push("tcp://127.0.0.1:2202", :bind)
-  push3 = zmq_push("tcp://127.0.0.1:2203", :bind)
-  push4 = zmq_push("tcp://127.0.0.1:2204", :bind)
-  push5 = zmq_push("tcp://127.0.0.1:2205", :bind)
 
   pull1 = zmq_pull("tcp://127.0.0.1:2201", :connect)
   pull2 = zmq_pull("tcp://127.0.0.1:2202", :connect)
-  pull3 = zmq_pull("tcp://127.0.0.1:2203", :connect)
-  pull4 = zmq_pull("tcp://127.0.0.1:2204", :connect)
-  pull5 = zmq_pull("tcp://127.0.0.1:2205", :connect)
-
-  #We'll switch out the message class for pull3 to show the difference
-  pull3.message_class = DripDrop::Message
 
   pull1.on_recv do |msg|
     puts "Pull 1 #{msg.head}"
@@ -46,27 +44,11 @@ DripDrop::Node.new do
 
   pull2.on_recv do |msg|
     puts "Pull 2 #{msg.head}"
-    sleep 1
-    push3.send_message(msg)
   end
 
-  #Remember that since we've switched this pull back to the standard
-  #message class of DripDrop::Message there will be no timestamp change here
-  pull3.on_recv do |msg|
-    puts "Pull 3 #{msg.head}"
-    sleep 1
-    push4.send_message(msg)
-  end
+  push1.send_message(TimestampedMessage.create_message(:name => 'test', :body => "Hello there"))
+end
 
-  pull4.on_recv do |msg|
-    puts "Pull 4 #{msg.head}"
-    sleep 1
-    push5.send_message(msg)
-  end
-
-  pull5.on_recv do |msg|
-    puts "Pull 5 #{msg.head}"
-  end
-
-  push1.send_message(:name => 'test', :body => "Hello there")
-end.start! #Start the reactor and block until complete
+node.start
+sleep 5
+node.stop

--- a/lib/dripdrop/handlers/zeromq.rb
+++ b/lib/dripdrop/handlers/zeromq.rb
@@ -16,6 +16,7 @@ class DripDrop
       @zm_reactor   = zm_reactor
       @socket_ctype = socket_ctype # :bind or :connect
       @debug        = opts[:debug] # TODO: Start actually using this
+      @opts         = opts
     end
 
     def on_attach(socket)
@@ -102,7 +103,7 @@ class DripDrop
 
     def initialize(*args)
       super(*args)
-      @message_class = DripDrop.default_message_class
+      @message_class = @opts[:msg_class] || DripDrop.default_message_class
     end
 
     def decode_message(msg)

--- a/lib/dripdrop/message.rb
+++ b/lib/dripdrop/message.rb
@@ -5,7 +5,7 @@ require 'json'
 class DripDrop
   # DripDrop::Message messages are exchanged between all tiers in the architecture
   # A Message is composed of a name, head, and body, and should be restricted to types that
-  # can be readily encoded to JSON. 
+  # can be readily encoded to JSON.
   # name: Any string
   # head: A hash containing anything (should be used for metadata)
   # body: anything you'd like, it can be null even
@@ -21,26 +21,27 @@ class DripDrop
   # These definitions are intentionally loose, because protocols tend to be used loosely.
   class Message
     attr_accessor :name, :head, :body
-    
+
     # Creates a new message.
     # example:
-    #   DripDrop::Message.new('mymessage', :head => {:timestamp => Time.now}, 
+    #   DripDrop::Message.new('mymessage', :head => {:timestamp => Time.now},
     #     :body => {:mykey => :myval,  :other_key => ['complex']})
     def initialize(name,extra={})
       raise ArgumentError, "Message names may not be empty or null!" if name.nil? || name.empty?
-       
+
       @head = extra[:head] || {}
       raise ArgumentError, "Invalid head #{@head}. Head must be a hash!" unless @head.is_a?(Hash)
-      
+      @head[:msg_class] = self.class.to_s
+
       @name = name
       @body = extra[:body]
     end
-    
+
     # The encoded message, ready to be sent across the wire via ZMQ
     def encoded
       BERT.encode(self.to_hash)
     end
-    
+
     # Encodes the hash represntation of the message to JSON
     def json_encoded
       self.to_hash.to_json
@@ -53,27 +54,40 @@ class DripDrop
     def to_hash
       {:name => @name, :head => @head, :body => @body}
     end
-    
+
     # Build a new Message from a hash that looks like
     #    {:name => name, :body => body, :head => head}
     def self.from_hash(hash)
       self.new(hash[:name],:head => hash[:head], :body => hash[:body])
     end
 
+    def self.create_message(*args)
+      case args[0]
+        when Hash then self.from_hash(args[0])
+        else self.new(args)
+      end
+    end
+
+    def self.recreate_message(hash)
+      raise ArgumentError, "Wrong message class #{hash[:head][:msg_class]} for #{self.to_s}" unless hash[:head][:msg_class] == self.to_s
+      self.from_hash(hash)
+    end
+
     # Parses an already encoded string
-    def self.decode(*args); self.parse(*args) end
-    # (Deprecated). Use decode instead
-    def self.parse(msg)
+    def self.decode(msg)
       return nil if msg.nil? || msg.empty?
       #This makes parsing ZMQ messages less painful, even if its ugly here
       #We check the class name as a string in case we don't have ZMQ loaded
       if msg.class.to_s == 'ZMQ::Message'
-        msg = msg.copy_out_string 
+        msg = msg.copy_out_string
         return nil if msg.empty?
       end
       decoded = BERT.decode(msg)
-      self.from_hash(decoded)
+      self.recreate_message(decoded)
     end
+
+    # (Deprecated). Use decode instead
+    def self.parse(msg); self.decode(msg) end
 
     # Decodes a string containing a JSON representation of a message
     def self.decode_json(str)
@@ -84,6 +98,58 @@ class DripDrop
         return nil
       end
       self.new(json_hash['name'], :head => json_hash['head'], :body => json_hash['body'])
+    end
+  end
+
+  #Use of this "metaclass" allows for the automatic recognition of the message's
+  #base class
+  class AutoMessageClass < Message
+    def initialize(*args)
+      raise "Cannot create an instance of this class - please use create_message class method"
+    end
+
+    class << self
+      attr_accessor :message_subclasses
+
+      DripDrop::AutoMessageClass.message_subclasses = {'DripDrop::Message' => DripDrop::Message}
+
+      def verify_args(*args)
+        head =
+          case args[0]
+            when Hash then args[0][:head]
+            else args[1]
+          end
+        raise ArgumentError, "Invalid head #{head}. Head must be a hash!" unless head.is_a?(Hash)
+
+        msg_class = head[:msg_class]
+        unless DripDrop::AutoMessageClass.message_subclasses.has_key?(msg_class)
+          raise ArgumentError, "Unknown AutoMessage message class #{msg_class}"
+        end
+
+        DripDrop::AutoMessageClass.message_subclasses[msg_class]
+      end
+
+      def create_message(*args)
+        klass = verify_args(*args)
+        klass.create_message(*args)
+      end
+
+      def recreate_message(*args)
+        klass = verify_args(*args)
+        klass.recreate_message(*args)
+      end
+
+      def register_subclass(klass)
+        DripDrop::AutoMessageClass.message_subclasses[klass.to_s] = klass
+      end
+    end
+  end
+
+  #Including this module into your subclass will automatically register the class
+  #with AutoMessageClass
+  module SubclassedMessage
+    def self.included(base)
+      DripDrop::AutoMessageClass.register_subclass base
     end
   end
 end


### PR DESCRIPTION
These are adds/mods to allow for the subclassing of DripDrop::Message to add additional functionality to the message itself if needed.

The example is a little contrived but it does show the subclassing of the Message class.
