### PR TITLE
Ruby19 const missing PLATFORM

### DIFF
--- a/lib/dripdrop/message.rb
+++ b/lib/dripdrop/message.rb
@@ -1,6 +1,6 @@
 require 'rubygems'
 
-if PLATFORM == 'java'
+if RUBY_PLATFORM == 'java'
   require 'json'
 else
   require 'yajl'


### PR DESCRIPTION
Ruby 1.9.2 is missing PLATFORM constant, having RUBY_PLATFORM instead. In JRuby RUBY_PLATFORM constant is equal to PLATFORM. So using RUBY_PLATFORM constant plays well with both versions.
